### PR TITLE
Add Next.js frontend with chat UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+frontend/.next
+frontend/node_modules

--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ src/
 The skeleton references several external services and frameworks including
 OpenAI, Google APIs, Playwright, Apify, Bull/Redis, Supabase and Nodemailer.
 All service modules currently contain placeholder functions to be implemented.
+
+## Frontend Chat UI
+
+A basic chat-like interface is available under the `frontend` directory. It uses Next.js and provides a minimal chat window and message input box.
+
+### Running the frontend
+
+```bash
+cd frontend
+npm install # install dependencies
+npm run dev
+```
+
+This will start the Next.js development server on <http://localhost:3000>.

--- a/frontend/components/ChatInput.js
+++ b/frontend/components/ChatInput.js
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+export default function ChatInput({ onSend }) {
+  const [text, setText] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    onSend(text.trim());
+    setText('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex' }}>
+      <input
+        type="text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        style={{ flex: 1, padding: '0.5rem' }}
+        placeholder="Type a message"
+      />
+      <button type="submit" style={{ padding: '0.5rem 1rem' }}>Send</button>
+    </form>
+  );
+}

--- a/frontend/components/ChatWindow.js
+++ b/frontend/components/ChatWindow.js
@@ -1,0 +1,11 @@
+export default function ChatWindow({ messages }) {
+  return (
+    <div style={{ flex: 1, overflowY: 'auto', padding: '1rem', border: '1px solid #ccc', marginBottom: '1rem' }}>
+      {messages.map((msg, idx) => (
+        <div key={idx} style={{ marginBottom: '0.5rem' }}>
+          <strong>{msg.sender}: </strong>{msg.text}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "leadgen-frontend",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import ChatWindow from '../components/ChatWindow';
+import ChatInput from '../components/ChatInput';
+import styles from '../styles/Home.module.css';
+
+export default function Home() {
+  const [messages, setMessages] = useState([]);
+
+  const handleSend = (text) => {
+    setMessages([...messages, { text, sender: 'user' }]);
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>LeadGen Chat</h1>
+      <ChatWindow messages={messages} />
+      <ChatInput onSend={handleSend} />
+    </div>
+  );
+}

--- a/frontend/styles/Home.module.css
+++ b/frontend/styles/Home.module.css
@@ -1,0 +1,13 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.title {
+  text-align: center;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- add simple Next.js app under `frontend` with chat UI components
- create `.gitignore` for Node artifacts
- update README with instructions for the new frontend

## Testing
- `npm test`