### PR TITLE
Implement OpenAI client generate function

### DIFF
--- a/src/services/ai/openai-client.js
+++ b/src/services/ai/openai-client.js
@@ -1,10 +1,32 @@
 const { OpenAI } = require('openai');
 
+const apiKey = process.env.OPENAI_API_KEY;
+
+if (!apiKey) {
+  throw new Error(
+    'Missing OpenAI API key. Please set OPENAI_API_KEY in your environment.'
+  );
+}
+
+const client = new OpenAI({ apiKey });
+
 // Wrapper around the OpenAI completion API. GPT-4 is preferred with a
 // fallback to GPT-3.5-turbo when context limits are exceeded.
 async function generate(prompt) {
-  // TODO: call OpenAI using new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
-  return '';
+  const models = ['gpt-4', 'gpt-3.5-turbo'];
+  for (const model of models) {
+    try {
+      const res = await client.chat.completions.create({
+        model,
+        messages: [{ role: 'user', content: prompt }]
+      });
+      return res.choices[0].message.content.trim();
+    } catch (err) {
+      if (model === 'gpt-3.5-turbo') {
+        throw err;
+      }
+    }
+  }
 }
 
 module.exports = { generate };


### PR DESCRIPTION
## Summary
- flesh out `openai-client.js` to instantiate OpenAI with `process.env.OPENAI_API_KEY`
- implement `generate` helper that prefers GPT‑4 and falls back to GPT‑3.5
- throw a clear error if the API key is missing

## Testing
- `npm test`