### PR TITLE
Initialize Bull queues and Supabase connection

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,6 +6,7 @@ function loadConfig() {
     logLevel: process.env.LOG_LEVEL || 'info',
     supabaseUrl: process.env.SUPABASE_URL,
     supabaseAnonKey: process.env.SUPABASE_ANON_KEY,
+    supabaseServiceKey: process.env.SUPABASE_SERVICE_KEY,
     openAIApiKey: process.env.OPENAI_API_KEY,
     googleSearchApiKey: process.env.GOOGLE_SEARCH_API_KEY,
     googleSearchEngineId: process.env.GOOGLE_SEARCH_ENGINE_ID,

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,30 @@
 const { loadConfig } = require('./config');
 const logger = require('./utils/logger');
+const Queue = require('bull');
+const { createClient } = require('@supabase/supabase-js');
+
+const researchWorker = require('./workers/research-worker');
+const emailWorker = require('./workers/email-worker');
+const analyticsWorker = require('./workers/analytics-worker');
 
 async function main() {
   const config = loadConfig();
   logger.info('LeadGen DUX started with config', config);
-  // TODO: initialize Bull queues, database connections and workers
+  // Create Bull queues
+  const researchQueue = new Queue('research', config.redisUrl);
+  const emailQueue = new Queue('email', config.redisUrl);
+  const analyticsQueue = new Queue('analytics', config.redisUrl);
+
+  // Connect to Supabase
+  const supabaseKey = config.supabaseServiceKey || config.supabaseAnonKey;
+  const supabase = createClient(config.supabaseUrl, supabaseKey);
+
+  // Register workers to process jobs
+  researchQueue.process(job => researchWorker(job.data, supabase));
+  emailQueue.process(job => emailWorker(job.data, supabase));
+  analyticsQueue.process(job => analyticsWorker(job.data, supabase));
+
+  logger.info('Queues initialized and workers registered');
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- add Supabase service key to configuration
- create job queues for research, email and analytics
- connect to Supabase and register workers

## Testing
- `npm test`