### PR TITLE
Implement research strategy engine

### DIFF
--- a/src/services/research/strategy-engine.js
+++ b/src/services/research/strategy-engine.js
@@ -1,0 +1,36 @@
+// Determine research strategy based on available lead data
+function determineStrategy(leadData) {
+  const strategies = [];
+
+  if (leadData.linkedin_url) {
+    strategies.push({
+      tool: 'browseruse',
+      priority: 1,
+      target: leadData.linkedin_url
+    });
+  }
+
+  if (leadData.company) {
+    const namePart = leadData.name ? ` ${leadData.name}` : '';
+    strategies.push({
+      tool: 'google_search',
+      priority: 2,
+      query: `${leadData.company}${namePart} news`
+    });
+  }
+
+  if (leadData.email) {
+    const parts = leadData.email.split('@');
+    if (parts[1]) {
+      strategies.push({
+        tool: 'browseruse',
+        priority: 3,
+        target: `https://${parts[1]}`
+      });
+    }
+  }
+
+  return strategies.sort((a, b) => a.priority - b.priority).slice(0, 3);
+}
+
+module.exports = { determineStrategy };

--- a/src/workers/research-worker.js
+++ b/src/workers/research-worker.js
@@ -1,10 +1,33 @@
 const { search } = require('../services/research/google-search');
+const { fetchDynamicContent } = require('../services/research/browser-automation');
+const { determineStrategy } = require('../services/research/strategy-engine');
 const logger = require('../utils/logger');
 
-// Worker executed from a Bull queue to perform research tasks
-module.exports = async function researchWorker(query) {
-  logger.info('Researching', query);
-  const results = await search(query);
+// Worker executed from a Bull queue to perform research tasks based on lead data
+module.exports = async function researchWorker(leadData) {
+  logger.info('Researching lead', leadData);
+
+  const strategies = determineStrategy(leadData);
+  logger.info('Selected strategies', strategies);
+
+  const results = [];
+
+  for (const strategy of strategies) {
+    try {
+      if (strategy.tool === 'google_search') {
+        const searchResults = await search(strategy.query);
+        results.push({ tool: 'google_search', query: strategy.query, results: searchResults });
+      } else if (strategy.tool === 'browseruse') {
+        const content = await fetchDynamicContent(strategy.target);
+        results.push({ tool: 'browseruse', target: strategy.target, content });
+      } else {
+        logger.warn(`Unknown research tool: ${strategy.tool}`);
+      }
+    } catch (err) {
+      logger.error(`Failed to execute ${strategy.tool}`, err);
+    }
+  }
+
   logger.info('Results', results);
   return results;
 };


### PR DESCRIPTION
## Summary
- add strategy engine to pick research tools based on lead data
- execute research tasks in worker using the selected strategy

## Testing
- `npm test`