### PR TITLE
Implement lead qualification utilities

### DIFF
--- a/src/services/database/supabase-client.js
+++ b/src/services/database/supabase-client.js
@@ -1,5 +1,6 @@
 const { createClient } = require('@supabase/supabase-js');
 const logger = require('../../utils/logger');
+const { isLeadQualified, calculateLeadScore, MINIMUM_SCORE_THRESHOLD } = require('../../utils/lead-quality');
 
 // Initialize Supabase client with service key for inserts and updates.
 const supabase = createClient(
@@ -9,9 +10,22 @@ const supabase = createClient(
 
 // Persist a qualified lead to the database and return the inserted id.
 async function storeLead(lead) {
+  if (!isLeadQualified(lead)) {
+    logger.warn('Lead failed qualification check');
+    return null;
+  }
+
+  const score = calculateLeadScore(lead);
+  if (score < MINIMUM_SCORE_THRESHOLD) {
+    logger.warn(`Lead score ${score} below threshold`);
+    return null;
+  }
+
+  const leadWithScore = { ...lead, score };
+
   const { data, error } = await supabase
     .from('leads')
-    .insert([lead])
+    .insert([leadWithScore])
     .select()
     .single();
 

--- a/src/services/email/campaign-manager.js
+++ b/src/services/email/campaign-manager.js
@@ -1,10 +1,23 @@
 const Queue = require('bull');
 const emailQueue = new Queue('email', process.env.REDIS_URL);
+const { isLeadQualified, calculateLeadScore, MINIMUM_SCORE_THRESHOLD } = require('../../utils/lead-quality');
+const logger = require('../../utils/logger');
 
 // Schedule a sequence of emails for a lead using Bull queue.
-async function scheduleCampaign(leadId, emails) {
+async function scheduleCampaign(lead, emails) {
+  if (!isLeadQualified(lead)) {
+    logger.warn('Lead failed qualification check, campaign not scheduled');
+    return null;
+  }
+
+  const score = calculateLeadScore(lead);
+  if (score < MINIMUM_SCORE_THRESHOLD) {
+    logger.warn(`Lead score ${score} below threshold, campaign not scheduled`);
+    return null;
+  }
+
   // TODO: push each email in the sequence to emailQueue.add()
-  return leadId;
+  return lead.id;
 }
 
 module.exports = { scheduleCampaign };

--- a/src/utils/lead-quality.js
+++ b/src/utils/lead-quality.js
@@ -1,0 +1,44 @@
+// Lead qualification and scoring utilities
+
+const REQUIRED_FIELDS = ['name', 'email'];
+const MINIMUM_ENRICHMENT_FIELDS = 2; // linkedin, website, company_info, social_profiles
+
+const FIELD_WEIGHTS = {
+  name: 10,
+  email: 10,
+  company: 15,
+  title: 10,
+  linkedin_url: 20,
+  recent_activity: 15,
+  company_info: 10,
+  personal_interests: 10
+};
+
+const MINIMUM_SCORE_THRESHOLD = 45;
+
+function isLeadQualified(lead) {
+  const hasRequired = REQUIRED_FIELDS.every((field) => Boolean(lead[field]));
+  const enrichmentCount = [
+    Boolean(lead.linkedin_url),
+    Boolean(lead.website_url),
+    Boolean(lead.company_info),
+    Boolean(lead.social_profiles)
+  ].filter(Boolean).length;
+  return hasRequired && enrichmentCount >= MINIMUM_ENRICHMENT_FIELDS;
+}
+
+function calculateLeadScore(lead) {
+  let score = 0;
+  for (const [field, weight] of Object.entries(FIELD_WEIGHTS)) {
+    if (lead[field]) {
+      score += weight;
+    }
+  }
+  return Math.min(score, 100);
+}
+
+module.exports = {
+  isLeadQualified,
+  calculateLeadScore,
+  MINIMUM_SCORE_THRESHOLD
+};


### PR DESCRIPTION
## Summary
- add lead qualification and scoring utility module
- validate leads before storing to Supabase
- check qualification before scheduling campaigns

## Testing
- `npm test`