### PR TITLE
Implement email campaign queue and worker

### DIFF
--- a/src/services/email/campaign-manager.js
+++ b/src/services/email/campaign-manager.js
@@ -2,8 +2,20 @@ const Queue = require('bull');
 const emailQueue = new Queue('email', process.env.REDIS_URL);
 
 // Schedule a sequence of emails for a lead using Bull queue.
-async function scheduleCampaign(leadId, emails) {
-  // TODO: push each email in the sequence to emailQueue.add()
+// `emails` should be an array where each entry contains the message
+// payload accepted by gmail-client along with an optional `delay`
+// property (in milliseconds) indicating when the email should be sent.
+async function scheduleCampaign(leadId, emails = []) {
+  for (let i = 0; i < emails.length; i++) {
+    const email = emails[i] || {};
+    const { delay = 0, ...payload } = email;
+
+    await emailQueue.add(
+      { leadId, ...payload },
+      delay ? { delay } : undefined
+    );
+  }
+
   return leadId;
 }
 

--- a/src/workers/email-queue-worker.js
+++ b/src/workers/email-queue-worker.js
@@ -1,0 +1,15 @@
+const Queue = require('bull');
+const { sendEmail } = require('../services/email/gmail-client');
+const logger = require('../utils/logger');
+
+// Worker that processes jobs from the email Bull queue and sends emails
+const emailQueue = new Queue('email', process.env.REDIS_URL);
+
+emailQueue.process(async job => {
+  const { leadId, ...message } = job.data || {};
+  logger.info(`Sending email for lead ${leadId}`);
+  await sendEmail(message);
+  logger.info('Email sent');
+});
+
+module.exports = emailQueue;


### PR DESCRIPTION
## Summary
- enqueue outbound emails with Bull
- add a worker that sends queued emails via Gmail

## Testing
- `npm test`