### PR TITLE
Implement Supabase tracking & analytics worker

### DIFF
--- a/src/services/database/supabase-client.js
+++ b/src/services/database/supabase-client.js
@@ -23,4 +23,62 @@ async function storeLead(lead) {
   return data.id;
 }
 
-module.exports = { storeLead, supabase };
+// Record an email tracking event (open/click) using the message_id field on
+// the email_campaigns table. `event` should contain `{ type, messageId }`.
+async function recordEmailEvent(event) {
+  const { type, messageId } = event;
+  if (!type || !messageId) {
+    throw new Error('Missing type or messageId');
+  }
+
+  const update = {};
+  const now = new Date().toISOString();
+  if (type === 'open') {
+    update.opened = true;
+    update.opened_at = now;
+  } else if (type === 'click') {
+    update.clicked = true;
+    update.clicked_at = now;
+  } else if (type === 'reply') {
+    update.replied = true;
+    update.replied_at = now;
+  } else if (type === 'bounce') {
+    update.bounced = true;
+  } else if (type === 'unsubscribe') {
+    update.unsubscribed = true;
+  } else {
+    throw new Error(`Unsupported event type: ${type}`);
+  }
+
+  const { error } = await supabase
+    .from('email_campaigns')
+    .update(update)
+    .eq('message_id', messageId);
+
+  if (error) {
+    logger.error('Failed to record email event', error);
+    throw error;
+  }
+
+  return true;
+}
+
+// Upsert a metric value into the analytics_metrics table. The table is expected
+// to have columns `metric` (primary key) and `value`.
+async function upsertMetric(metric, value) {
+  const { error } = await supabase
+    .from('analytics_metrics')
+    .upsert({ metric, value }, { onConflict: 'metric' });
+
+  if (error) {
+    logger.error('Failed to upsert metric', error);
+    throw error;
+  }
+}
+
+module.exports = {
+  storeLead,
+  supabase,
+  recordEmailEvent,
+  upsertMetric,
+};

--- a/src/services/email/tracking.js
+++ b/src/services/email/tracking.js
@@ -1,6 +1,15 @@
-// Track email opens and clicks via webhooks or tracking pixels.
+const { recordEmailEvent } = require('../database/supabase-client');
+const logger = require('../../utils/logger');
+
+// Track email events (open, click, reply, bounce, unsubscribe) by persisting
+// them to Supabase. `event` should contain `{ type, messageId }`.
 async function track(event) {
-  // TODO: store event in Supabase or analytics service
+  try {
+    await recordEmailEvent(event);
+  } catch (err) {
+    logger.error('Failed to record tracking event', err);
+  }
+
   return event;
 }
 

--- a/src/workers/analytics-worker.js
+++ b/src/workers/analytics-worker.js
@@ -1,7 +1,64 @@
 const logger = require('../utils/logger');
+const { supabase, upsertMetric } = require('../services/database/supabase-client');
+const { track } = require('../services/email/tracking');
 
-// Worker that records engagement metrics for sent emails
+// Worker that records engagement metrics for sent emails. Expects an event
+// object containing at least `{ type, messageId }`.
 module.exports = async function analyticsWorker(event) {
   logger.info('Tracking event', event);
-  // TODO: implement analytics
+
+  // Persist the raw tracking event first
+  await track(event);
+
+  // Recalculate email performance metrics defined in Agent.md section 12
+  const { count: sentCount } = await supabase
+    .from('email_campaigns')
+    .select('*', { count: 'exact', head: true })
+    .not('sent_at', 'is', null);
+
+  if (sentCount === null) {
+    logger.error('Unable to compute metrics: failed to count sent emails');
+    return;
+  }
+
+  const { count: openedCount } = await supabase
+    .from('email_campaigns')
+    .select('*', { count: 'exact', head: true })
+    .eq('opened', true);
+
+  const { count: clickedCount } = await supabase
+    .from('email_campaigns')
+    .select('*', { count: 'exact', head: true })
+    .eq('clicked', true);
+
+  const { count: repliedCount } = await supabase
+    .from('email_campaigns')
+    .select('*', { count: 'exact', head: true })
+    .eq('replied', true);
+
+  const { count: bouncedCount } = await supabase
+    .from('email_campaigns')
+    .select('*', { count: 'exact', head: true })
+    .eq('bounced', true);
+
+  const { count: unsubCount } = await supabase
+    .from('email_campaigns')
+    .select('*', { count: 'exact', head: true })
+    .eq('unsubscribed', true);
+
+  const openRate = sentCount ? openedCount / sentCount : 0;
+  const clickRate = sentCount ? clickedCount / sentCount : 0;
+  const replyRate = sentCount ? repliedCount / sentCount : 0;
+  const bounceRate = sentCount ? bouncedCount / sentCount : 0;
+  const unsubscribeRate = sentCount ? unsubCount / sentCount : 0;
+
+  await Promise.all([
+    upsertMetric('open_rate', openRate),
+    upsertMetric('click_rate', clickRate),
+    upsertMetric('reply_rate', replyRate),
+    upsertMetric('bounce_rate', bounceRate),
+    upsertMetric('unsubscribe_rate', unsubscribeRate),
+  ]);
+
+  logger.info('Analytics metrics updated');
 };


### PR DESCRIPTION
## Summary
- store tracking events in Supabase
- update analytics metrics whenever an event is processed

## Testing
- `npm test`