### PR TITLE
Add testing setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "test": "echo \"No tests yet\""
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.38.0",

--- a/src/utils/lead-qualification.js
+++ b/src/utils/lead-qualification.js
@@ -1,0 +1,16 @@
+const REQUIRED_FIELDS = ['name', 'email'];
+const MINIMUM_ENRICHMENT_FIELDS = 2;
+
+function isLeadQualified(lead) {
+  const hasRequired = REQUIRED_FIELDS.every(field => !!lead[field]);
+  const enrichmentCount = [
+    'linkedin_url',
+    'website_url',
+    'company_info',
+    'social_profiles'
+  ].reduce((count, field) => count + (lead[field] ? 1 : 0), 0);
+
+  return hasRequired && enrichmentCount >= MINIMUM_ENRICHMENT_FIELDS;
+}
+
+module.exports = { isLeadQualified };

--- a/tests/example.test.js
+++ b/tests/example.test.js
@@ -1,2 +1,0 @@
-// Placeholder test using Jest
-console.log('Tests not implemented');

--- a/tests/leadgen.test.js
+++ b/tests/leadgen.test.js
@@ -1,0 +1,83 @@
+const { isLeadQualified } = require('../src/utils/lead-qualification');
+const { personalize } = require('../src/services/ai/personalization');
+const { generate } = require('../src/services/ai/openai-client');
+const { search } = require('../src/services/research/google-search');
+
+jest.mock('../src/services/ai/openai-client');
+jest.mock('../src/services/research/google-search');
+
+describe('Lead qualification', () => {
+  test('returns true when lead has required and enrichment fields', () => {
+    const lead = {
+      name: 'John',
+      email: 'john@example.com',
+      linkedin_url: 'https://linkedin.com/in/john',
+      company_info: 'info'
+    };
+    expect(isLeadQualified(lead)).toBe(true);
+  });
+
+  test('returns false when missing enrichment', () => {
+    const lead = { name: 'Jane', email: 'jane@example.com' };
+    expect(isLeadQualified(lead)).toBe(false);
+  });
+});
+
+describe('Email personalization', () => {
+  test('replaces tokens in template', () => {
+    const result = personalize('Hello {{name}}', { name: 'Alice' });
+    expect(result).toBe('Hello Alice');
+  });
+
+  test('missing token results in empty string', () => {
+    const result = personalize('Hi {{unknown}}', {});
+    expect(result).toBe('Hi ');
+  });
+});
+
+describe('API integrations', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('OpenAI generate falls back to second model', async () => {
+    const mockCreate = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({ choices: [{ message: { content: 'hi' } }] });
+    generate.mockImplementation(async (prompt) => {
+      const { OpenAI } = require('openai');
+      const client = new OpenAI();
+      return await client.chat.completions.create(prompt);
+    });
+    jest.doMock('openai', () => ({
+      OpenAI: jest.fn().mockImplementation(() => ({
+        chat: { completions: { create: mockCreate } }
+      }))
+    }));
+
+    // Re-require after mocking
+    const { generate: gen } = require('../src/services/ai/openai-client');
+    const result = await gen('prompt');
+    expect(result).toBe('hi');
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+  });
+
+  test('Google search returns formatted results', async () => {
+    const list = jest.fn().mockResolvedValue({
+      data: { items: [{ title: 't', link: 'l', snippet: 's' }] }
+    });
+    search.mockImplementation(async (query) => {
+      const { google } = require('googleapis');
+      const customsearch = google.customsearch('v1');
+      return await customsearch.cse.list({ q: query });
+    });
+    jest.doMock('googleapis', () => ({
+      google: { customsearch: jest.fn(() => ({ cse: { list } })) }
+    }));
+
+    const { search: searchFn } = require('../src/services/research/google-search');
+    const res = await searchFn('query');
+    expect(res).toEqual([{ title: 't', link: 'l', snippet: 's' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `isLeadQualified` utility
- replace placeholder test with unit tests for lead qualification, email personalization and mocked API integrations
- configure `npm test` to run Jest with coverage

## Testing
- `npm test` *(fails: jest not found)*