### PR TITLE
Remove Redis and use Supabase-backed queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,6 @@ GMAIL_REFRESH_TOKEN=xxxxx
 FROM_EMAIL=outreach@company.com
 REPLY_TO_EMAIL=replies@company.com
 
-# Redis Queue
-REDIS_URL=redis://localhost:6379
 
 # Application
 NODE_ENV=development

--- a/Agent.md
+++ b/Agent.md
@@ -79,7 +79,7 @@ def is_lead_qualified(lead_data):
                                 │
                     ┌───────────┴───────────┐
                     │   Queue/Job System    │
-                    │  (Redis/Bull Queue)   │
+                    │  (Supabase Queue)     │
                     └───────────┬───────────┘
                                 │
                     ┌───────────┴───────────┐
@@ -429,8 +429,6 @@ GMAIL_REFRESH_TOKEN=xxxxx
 FROM_EMAIL=outreach@company.com
 REPLY_TO_EMAIL=replies@company.com
 
-# Redis Queue
-REDIS_URL=redis://localhost:6379
 
 # Application
 NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ src/
 ```
 
 The skeleton references several external services and frameworks including
-OpenAI, Google APIs, Playwright, Apify, Bull/Redis, Supabase and Nodemailer.
+OpenAI, Google APIs, Playwright, Apify, Supabase and Nodemailer.
 All service modules currently contain placeholder functions to be implemented.
 
 ## Frontend Chat UI

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "@supabase/supabase-js": "^2.38.0",
     "openai": "^4.20.0",
     "playwright": "^1.40.0",
-    "bull": "^4.11.0",
-    "redis": "^4.6.0",
     "apify-client": "^2.7.0",
     "googleapis": "^128.0.0",
     "nodemailer": "^6.9.0",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -13,8 +13,7 @@ function loadConfig() {
     apifyToken: process.env.APIFY_API_TOKEN,
     gmailClientId: process.env.GMAIL_CLIENT_ID,
     gmailClientSecret: process.env.GMAIL_CLIENT_SECRET,
-    gmailRefreshToken: process.env.GMAIL_REFRESH_TOKEN,
-    redisUrl: process.env.REDIS_URL
+    gmailRefreshToken: process.env.GMAIL_REFRESH_TOKEN
   };
 }
 

--- a/src/services/email/campaign-manager.js
+++ b/src/services/email/campaign-manager.js
@@ -1,9 +1,16 @@
-const Queue = require('bull');
-const emailQueue = new Queue('email', process.env.REDIS_URL);
+const { createQueue } = require('../queue/supabase-queue');
+const { createClient } = require('@supabase/supabase-js');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_KEY
+);
+
+const emailQueue = createQueue('email', supabase);
 const { isLeadQualified, calculateLeadScore, MINIMUM_SCORE_THRESHOLD } = require('../../utils/lead-quality');
 const logger = require('../../utils/logger');
 
-// Schedule a sequence of emails for a lead using Bull queue.
+// Schedule a sequence of emails for a lead using the Supabase-backed queue.
 async function scheduleCampaign(lead, emails) {
   if (!isLeadQualified(lead)) {
     logger.warn('Lead failed qualification check, campaign not scheduled');

--- a/src/services/queue/supabase-queue.js
+++ b/src/services/queue/supabase-queue.js
@@ -1,0 +1,59 @@
+// Simple queue implementation backed by a Supabase table.
+// Jobs are stored in a "jobs" table with columns:
+// id (uuid), queue (text), payload (jsonb), status (text), created_at (timestamp).
+// Pending jobs have status 'pending'. When processed they change to 'completed'.
+
+const logger = require('../../utils/logger');
+
+function createQueue(name, supabase) {
+  async function add(data) {
+    const { error } = await supabase.from('jobs').insert({
+      queue: name,
+      payload: data,
+      status: 'pending',
+    });
+    if (error) {
+      logger.error(`Failed to add job to ${name} queue`, error);
+      throw error;
+    }
+  }
+
+  // Polling processor. intervalMs defines how frequently to check for jobs.
+  function process(handler, intervalMs = 1000) {
+    setInterval(async () => {
+      const { data: jobs, error } = await supabase
+        .from('jobs')
+        .select('*')
+        .eq('queue', name)
+        .eq('status', 'pending')
+        .order('created_at', { ascending: true })
+        .limit(1);
+
+      if (error) {
+        logger.error(`Failed to fetch jobs for ${name} queue`, error);
+        return;
+      }
+
+      if (!jobs || jobs.length === 0) return;
+
+      const job = jobs[0];
+      try {
+        await handler(job.payload);
+        const { error: updateError } = await supabase
+          .from('jobs')
+          .update({ status: 'completed' })
+          .eq('id', job.id);
+        if (updateError) {
+          logger.error(`Failed to mark job ${job.id} completed`, updateError);
+        }
+      } catch (err) {
+        logger.error(`Job ${job.id} failed`, err);
+        await supabase.from('jobs').update({ status: 'failed' }).eq('id', job.id);
+      }
+    }, intervalMs);
+  }
+
+  return { add, process };
+}
+
+module.exports = { createQueue };

--- a/src/utils/rate-limiter.js
+++ b/src/utils/rate-limiter.js
@@ -1,4 +1,5 @@
-// Simple in-memory rate limiter. For production use, store counts in Redis.
+// Simple in-memory rate limiter. For production use, store counts in a
+// persistent system such as Supabase.
 class RateLimiter {
   constructor(limit) {
     this.limit = limit;

--- a/src/workers/email-worker.js
+++ b/src/workers/email-worker.js
@@ -1,7 +1,7 @@
 const { sendEmail } = require('../services/email/gmail-client');
 const logger = require('../utils/logger');
 
-// Worker executed from the Bull queue to deliver outbound emails
+// Worker executed from the Supabase-backed queue to deliver outbound emails
 module.exports = async function emailWorker(message) {
   logger.info('Sending email');
   await sendEmail(message);

--- a/src/workers/research-worker.js
+++ b/src/workers/research-worker.js
@@ -3,7 +3,7 @@ const { fetchDynamicContent } = require('../services/research/browser-automation
 const { determineStrategy } = require('../services/research/strategy-engine');
 const logger = require('../utils/logger');
 
-// Worker executed from a Bull queue to perform research tasks based on lead data
+// Worker executed from the Supabase-backed queue to perform research tasks based on lead data
 module.exports = async function researchWorker(leadData) {
   logger.info('Researching lead', leadData);
 


### PR DESCRIPTION
## Summary
- drop bull/redis dependencies
- implement a simple Supabase-backed queue
- switch workers and campaign manager to use the new queue
- clean up environment variables and docs

## Testing
- `npm test` *(fails: jest not found)*