### PR TITLE
Integrate scheduling and proactive services

### DIFF
--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -1,0 +1,14 @@
+class NotificationService {
+    constructor(supabase) {
+        this.supabase = supabase;
+    }
+
+    async send(notification) {
+        await this.supabase.from('agent_notifications').insert({
+            ...notification,
+            created_at: new Date()
+        });
+    }
+}
+
+module.exports = { NotificationService };


### PR DESCRIPTION
## Summary
- wire up `LeadAssistant` with queues and task scheduler
- expose scheduling/analytics/research/reminder methods
- add basic notification service
- start proactive agent and assistant in main entry
- implement proactive agent helper methods

## Testing
- `npm test` *(fails: jest not found)*