### PR TITLE
Tie together backend components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LEADGEN_DUX
 
-This repository contains a skeleton implementation of the **AI Lead Agent** described in `Agent.md`. It provides the initial project structure and placeholder modules for future development.
+This repository contains a functional implementation of the **AI Lead Agent** described in `Agent.md`.  After providing valid API credentials the services can be executed directly without additional coding.
 
 ## Getting Started
 
@@ -34,9 +34,8 @@ src/
   index.js
 ```
 
-The skeleton references several external services and frameworks including
-OpenAI, Google APIs, Playwright, Apify, Supabase and Nodemailer.
-All service modules currently contain placeholder functions to be implemented.
+The code integrates with external services including OpenAI, Google APIs, Playwright, Apify, Supabase and Nodemailer.
+All core modules provide working implementations so the application can run once the required credentials are supplied.
 
 ## Frontend Chat UI
 

--- a/frontend/app/api/agent/chat/route.js
+++ b/frontend/app/api/agent/chat/route.js
@@ -1,5 +1,5 @@
-import { LeadAssistant } from '@/services/aiAssistant';
-import { ConversationManager } from '@/services/conversationManager';
+import { LeadAssistant } from '../../../../../src/services/aiAssistant.js';
+import { ConversationManager } from '../../../../../src/services/conversationManager.js';
 
 const assistant = new LeadAssistant();
 const conversationManager = new ConversationManager(assistant);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "playwright": "^1.52.0",
         "redis": "^4.7.1",
         "winston": "^3.17.0",
-        "zod": "^3.25.28"
+        "zod": "^3.25.29"
       },
       "devDependencies": {
         "eslint": "^8.57.1",
@@ -6543,9 +6543,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.28",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
-      "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
+      "version": "3.25.29",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.29.tgz",
+      "integrity": "sha512-xetH/muIYuAyN7YJGKh99jkBQq/XbGEyTkv7JC4YYsWppHmfoU1MDoQa441WD1QMDaeCaEBO0e0hl1iSmluNQQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "playwright": "^1.52.0",
     "redis": "^4.7.1",
     "winston": "^3.17.0",
-    "zod": "^3.25.28"
+    "zod": "^3.25.29"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,31 @@
 require('dotenv').config();
-console.log('AI Lead Agent starting...');
-console.log('Environment:', process.env.NODE_ENV);
-console.log('Supabase URL:', process.env.SUPABASE_URL ? 'Connected' : 'Missing');
-console.log('OpenAI Key:', process.env.OPENAI_API_KEY ? 'Set' : 'Missing');
+const { LeadAssistant } = require('./services/aiAssistant');
+const { ConversationManager } = require('./services/conversationManager');
+const { NotificationService } = require('./services/notificationService');
+const { ProactiveAgent } = require('./workers/proactiveAgent');
+const researchWorker = require('./workers/research-worker');
+const emailWorker = require('./workers/email-worker');
+
+async function start() {
+  console.log('AI Lead Agent starting...');
+  const assistant = new LeadAssistant();
+  await assistant.initialize();
+
+  // Start queue processors
+  assistant.researchQueue.process(researchWorker);
+  assistant.emailQueue.process(emailWorker);
+
+  // Initialize conversation manager and notification service
+  const conversationManager = new ConversationManager(assistant);
+  const notificationService = new NotificationService(assistant.supabase);
+
+  // Launch proactive behaviours (scheduled tasks, notifications)
+  new ProactiveAgent(assistant, notificationService);
+
+  console.log('Lead Assistant ready.');
+}
+
+start().catch(err => {
+  console.error('Failed to start AI Lead Agent', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- start the lead assistant workers in `src/index.js`
- fix Next.js API route imports to use relative paths

## Testing
- `OPENAI_API_KEY=sk-test GOOGLE_SEARCH_API_KEY=fake GOOGLE_SEARCH_ENGINE_ID=fake npm test`