### PR TITLE
Fix schedule parsing to use assistant method

### DIFF
--- a/src/services/taskScheduler.js
+++ b/src/services/taskScheduler.js
@@ -63,7 +63,7 @@ class TaskScheduler {
             parser.parseExpression(scheduleInput);
             return scheduleInput;
         } catch (error) {
-            return await this.interpretScheduleWithAI(scheduleInput);
+            return await this.assistant.interpretScheduleWithAI(scheduleInput);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure TaskScheduler calls the assistant's `interpretScheduleWithAI`

## Testing
- `npm test`