### PR TITLE
Add optional task scheduler disablement

### DIFF
--- a/tests/leadgen.test.js
+++ b/tests/leadgen.test.js
@@ -88,9 +88,10 @@ describe('API integrations', () => {
     process.env.SUPABASE_URL = 'http://localhost';
     process.env.SUPABASE_SERVICE_KEY = 'key';
     const { LeadAssistant } = require('../src/services/aiAssistant');
-    const assistant = new LeadAssistant();
+    const assistant = new LeadAssistant({ enableScheduling: false });
     const result = await assistant.googleSearch({ query: 'test' });
     expect(result).toEqual(['res']);
+    assistant.stopScheduledTasks();
   });
 
   test('LeadAssistant browserUse invokes browser automation', async () => {
@@ -99,9 +100,10 @@ describe('API integrations', () => {
     process.env.SUPABASE_URL = 'http://localhost';
     process.env.SUPABASE_SERVICE_KEY = 'key';
     const { LeadAssistant } = require('../src/services/aiAssistant');
-    const assistant = new LeadAssistant();
+    const assistant = new LeadAssistant({ enableScheduling: false });
     const result = await assistant.browserUse({ url: 'http://x.com' });
     expect(result).toBe('<html></html>');
+    assistant.stopScheduledTasks();
   });
 });
 


### PR DESCRIPTION
## Summary
- allow passing options to `LeadAssistant` constructor
- skip cron jobs when scheduler disabled
- support stopping scheduled tasks
- disable scheduler in tests

## Testing
- `npm test --silent`